### PR TITLE
Allow multiline selector lists without space after comma

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,7 +124,7 @@ module.exports = {
         'selector-descendant-combinator-no-non-space'    : true,
         'selector-list-comma-newline-after'              : 'always-multi-line',
         'selector-list-comma-newline-before'             : 'never-multi-line',
-        'selector-list-comma-space-after'                : 'always',
+        'selector-list-comma-space-after'                : 'always-single-line',
         'selector-list-comma-space-before'               : 'never',
         'selector-max-compound-selectors'                : 4,
         'selector-max-empty-lines'                       : 0,

--- a/test.js
+++ b/test.js
@@ -50,3 +50,15 @@ test('word blacklist is case insensitive', async (t) => {
 
     t.is(errors.length, 2);
 });
+
+test('multiline comma separated selector list', async (t) => {
+    const { errored } = await lintText('div,\np {\n    font-size: inherit;\n}\n');
+    t.false(errored);
+});
+
+test('single line comma separated selector list', async (t) => {
+    const { errored, results } = await lintText('div,p {\n    font-size: inherit;\n}\n');
+    t.true(errored);
+    const errors = getErrors(results, 'selector-list-comma-space-after');
+    t.is(errors.length, 1);
+});


### PR DESCRIPTION
Right now, the settings require a space after a comma in a selector list. But this conflicts with my editor settings which trim all whitespace before newlines. This PR will fix that.